### PR TITLE
Clean up port option

### DIFF
--- a/1.1.20/Dockerfile
+++ b/1.1.20/Dockerfile
@@ -2,7 +2,6 @@ FROM alpine:3.16
 
 ENV GEARMAND_VERSION 1.1.20
 ENV GEARMAND_SHA1 054b3d7f7f6e0fae982fb1d467db5902b0b11ddc
-ENV GEARMAND_LISTEN_PORT 4730
 
 RUN addgroup -S gearman && adduser -G gearman -S -D -H -s /bin/false -g "Gearman Server" gearman
 

--- a/1.1.20/docker-entrypoint.sh
+++ b/1.1.20/docker-entrypoint.sh
@@ -3,6 +3,7 @@ set -eo pipefail
 CONFIG_FILE='/etc/gearmand.conf'
 
 VERBOSE=${VERBOSE:-INFO}
+LISTEN_PORT=${LISTEN_PORT:-4730}
 QUEUE_TYPE=${QUEUE_TYPE:-builtin}
 
 THREADS=${THREADS:-4}
@@ -48,7 +49,7 @@ fi
 function generate_config() {
 	cat <<-__CONFIG_CONTENT__ > "${CONFIG_FILE}"
 		--listen=0.0.0.0
-		--port=${GEARMAND_LISTEN_PORT}
+		--port=${LISTEN_PORT}
 		--log-file=stderr
 		--verbose=${VERBOSE}
 		--queue-type=${QUEUE_TYPE}

--- a/1.1.21/Dockerfile
+++ b/1.1.21/Dockerfile
@@ -2,7 +2,6 @@ FROM alpine:3.18
 
 ENV GEARMAND_VERSION 1.1.21
 ENV GEARMAND_SHA1 472d2a0019e69edefcd0c1ff57e9352982e6d3f5
-ENV GEARMAND_LISTEN_PORT 4730
 
 RUN addgroup -S gearman && adduser -G gearman -S -D -H -s /bin/false -g "Gearman Server" gearman
 

--- a/1.1.21/docker-entrypoint.sh
+++ b/1.1.21/docker-entrypoint.sh
@@ -3,6 +3,7 @@ set -eo pipefail
 CONFIG_FILE='/etc/gearmand.conf'
 
 VERBOSE=${VERBOSE:-INFO}
+LISTEN_PORT=${LISTEN_PORT:-4730}
 QUEUE_TYPE=${QUEUE_TYPE:-builtin}
 
 THREADS=${THREADS:-4}
@@ -48,7 +49,7 @@ fi
 function generate_config() {
 	cat <<-__CONFIG_CONTENT__ > "${CONFIG_FILE}"
 		--listen=0.0.0.0
-		--port=${GEARMAND_LISTEN_PORT}
+		--port=${LISTEN_PORT}
 		--log-file=stderr
 		--verbose=${VERBOSE}
 		--queue-type=${QUEUE_TYPE}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This image includes an entry point that translates environment strings into [con
 | Name                | Description                                                                                                                              | Default                         |
 |---------------------|------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | VERBOSE             | Logging level                                                                                                                            | INFO                            |
+| LISTEN_PORT         | Listen port                                                                                                                              | 4730                            |
 | QUEUE_TYPE          | Persistent queue type to use                                                                                                             | builtin                         |
 | THREADS             | Number of I/O threads to use                                                                                                             | 4                               |
 | BACKLOG             | Number of backlog connections for listen                                                                                                 | 32                              |
@@ -54,14 +55,13 @@ This image includes an entry point that translates environment strings into [con
 | KEEPALIVE_IDLE      | The duration between two keepalive transmissions in idle condition                                                                       | 30                              |
 | KEEPALIVE_INTERVAL  | The duration between two successive keepalive retransmissions, if acknowledgement to the previous keepalive transmission is not received | 10                              |
 | KEEPALIVE_COUNT     | The number of retransmissions to be carried out before declaring that remote end is not available                                        | 5                               |
-| MYSQL_HOST          | Mysql server host                                                                                                                        | localhost                       |
-| MYSQL_PORT          | Mysql server port                                                                                                                        | 3306                            |
-| MYSQL_USER          | Mysql server user                                                                                                                        | root                            |
-| MYSQL_PASSWORD      | Mysql password                                                                                                                           |                                 |
-| MYSQL_PASSWORD_FILE | Path to file with mysql password(Docker secrets)                                                                                         |                                 |
+| MYSQL_HOST          | MySQL server host                                                                                                                        | localhost                       |
+| MYSQL_PORT          | MySQL server port                                                                                                                        | 3306                            |
+| MYSQL_USER          | MySQL server user                                                                                                                        | root                            |
+| MYSQL_PASSWORD      | MySQL password                                                                                                                           |                                 |
+| MYSQL_PASSWORD_FILE | Path to file with MySQL password (Docker secrets)                                                                                        |                                 |
 | MYSQL_DB            | Database to use by Gearman                                                                                                               | Gearmand                        |
 | MYSQL_TABLE         | Table to use by Gearman                                                                                                                  | gearman_queue                   |
-| GEARMAND_LISTEN_PORT | Gearmand listen port                                                                                                                    | 4730                            |
 
 You can also inject your version of config file to `/etc/gearmand.conf` as needed.
 


### PR DESCRIPTION
It should read `LISTEN_PORT` instead of `GEARMAND_LISTEN_PORT` to be consistent with other environment strings.